### PR TITLE
Added a ping thread, so that the WS client crashes when it should

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -116,6 +116,7 @@ runBot conf bot start = do
 mkBot :: (Metainfo -> SlackState s) -> SlackBot s -> WS.ClientApp ()
 mkBot partialState bot conn = do
     let initMeta = Meta conn 0
+    WS.forkPingThread conn 10
     botLoop (partialState initMeta) bot
 
 botLoop :: forall s . SlackState s -> SlackBot s -> IO ()


### PR DESCRIPTION
I've had a small problem: when my computer goes to sleep mode, the websocket connection get severed (after a timeout), but this is not detected and the bot simply hangs.

I solved that by adding a ping every 10 seconds (the websockets package provide a nice function for this). Now, when the connection is severed, an IOException is raised and I can restart the bot.