### PR TITLE
Raised the upper bound for errors from <2.0 to <3.0

### DIFF
--- a/slack-api.cabal
+++ b/slack-api.cabal
@@ -79,7 +79,7 @@ Library
     mtl >= 2.1,
     aeson >= 0.8 ,
     time-locale-compat >= 0.1 && < 0.2,
-    errors >= 1.4 && < 2.0,
+    errors >= 1.4 && < 3.0,
     monad-loops >= 0.4,
     transformers >= 0.3,
     time >= 1.4


### PR DESCRIPTION
We only use readz from errors, and it wasn't affected by the interface
change, so it is safe use errors 2.0