### PR TITLE
Add 'reaction_added' and 'reaction_removed' events

### DIFF
--- a/src/Web/Slack/Types/Event.hs
+++ b/src/Web/Slack/Types/Event.hs
@@ -71,6 +71,8 @@ data Event where
   PrefChange :: Pref -> Event
   UserChange :: User -> Event
   TeamJoin :: User -> Event
+  ReactionAdded :: UserId -> Text -> Item -> SlackTimeStamp -> Event
+  ReactionRemoved :: UserId -> Text -> Item -> SlackTimeStamp -> Event
   StarAdded :: UserId -> Item -> SlackTimeStamp -> Event
   StarRemoved :: UserId -> Item -> SlackTimeStamp -> Event
   EmojiChanged :: SlackTimeStamp -> Event
@@ -160,6 +162,8 @@ parseType o@(Object v) typ =
       "pref_change" -> curry PrefChange <$> v .: "name" <*> v .: "value"
       "user_change" -> UserChange <$> v .: "user"
       "team_join"   -> TeamJoin <$> v .: "user"
+      "reaction_added" -> ReactionAdded <$> v .: "user" <*> v .:"name" <*> v .: "item" <*> v .: "event_ts"
+      "reaction_removed" -> ReactionRemoved <$> v .: "user" <*> v .:"name" <*> v .: "item" <*> v .: "event_ts"
       "star_added" ->  StarAdded <$> v .: "user" <*> v .: "item" <*> v .: "event_ts"
       "star_removed" -> StarRemoved <$> v .: "user" <*> v .: "item" <*> v .: "event_ts"
       "emoji_changed" -> EmojiChanged <$> v .: "event_ts"


### PR DESCRIPTION
This commit adds constructors and JSON parsing for [`reaction_added`](https://api.slack.com/events/reaction_added) and [`reaction_removed`](https://api.slack.com/events/reaction_removed) events.

This addresses [Issue 21](https://github.com/mpickering/slack-api/issues/21).