### PR TITLE
Add 'status_change' event

### DIFF
--- a/src/Web/Slack/Types/Event.hs
+++ b/src/Web/Slack/Types/Event.hs
@@ -85,6 +85,7 @@ data Event where
   UserTyping :: ChannelId -> UserId -> Event
   MessageResponse :: Int -> SlackTimeStamp -> Text -> Event
   MessageError :: Int -> SlackError -> Event
+  StatusChange :: UserId -> Text -> SlackTimeStamp -> Event
   Pong :: Time -> Event
   NoEvent :: Event
   deriving (Show)
@@ -171,6 +172,7 @@ parseType o@(Object v) typ =
       "bot_added" -> BotAdded <$> v .:  "bot"
       "bot_changed" -> BotChanged <$> v .: "bot"
       "accounts_changed" -> pure AccountsChanged
+      "status_change" -> StatusChange <$> v .: "user" <*> v .: "status" <*> v .: "event_ts"
       "pong" -> Pong <$> v .: "timestamp"
       _ -> fail $ "Unrecognised type: " <> T.unpack typ
 parseType _ _ = error "Expecting object"


### PR DESCRIPTION
This commit adds a constructor and JSON parsing for the `status_change` event.  This message doesn't appear to be documented in [the Slack RTM API docs](https://api.slack.com/rtm).  Googling doesn't turn up many hits, but there does seem to be a `status_change` message in Slack's official node/coffeescript bot [here](https://github.com/slackhq/node-slack-client/blob/master/src/client.coffee#L360).  I used that code and the error message from #20 to guess at the structure of this event, and it seems to work for me, but I guess it would be good to ask what's going on upstream as well.