### PR TITLE
Make the 'name' field of reaction events optional (this is undocumented)

### DIFF
--- a/src/Web/Slack/Types/Event.hs
+++ b/src/Web/Slack/Types/Event.hs
@@ -71,8 +71,8 @@ data Event where
   PrefChange :: Pref -> Event
   UserChange :: User -> Event
   TeamJoin :: User -> Event
-  ReactionAdded :: UserId -> Text -> Item -> SlackTimeStamp -> Event
-  ReactionRemoved :: UserId -> Text -> Item -> SlackTimeStamp -> Event
+  ReactionAdded :: UserId -> Maybe Text -> Item -> SlackTimeStamp -> Event
+  ReactionRemoved :: UserId -> Maybe Text -> Item -> SlackTimeStamp -> Event
   StarAdded :: UserId -> Item -> SlackTimeStamp -> Event
   StarRemoved :: UserId -> Item -> SlackTimeStamp -> Event
   EmojiChanged :: SlackTimeStamp -> Event
@@ -163,8 +163,8 @@ parseType o@(Object v) typ =
       "pref_change" -> curry PrefChange <$> v .: "name" <*> v .: "value"
       "user_change" -> UserChange <$> v .: "user"
       "team_join"   -> TeamJoin <$> v .: "user"
-      "reaction_added" -> ReactionAdded <$> v .: "user" <*> v .:"name" <*> v .: "item" <*> v .: "event_ts"
-      "reaction_removed" -> ReactionRemoved <$> v .: "user" <*> v .:"name" <*> v .: "item" <*> v .: "event_ts"
+      "reaction_added" -> ReactionAdded <$> v .: "user" <*> v .:? "name" <*> v .: "item" <*> v .: "event_ts"
+      "reaction_removed" -> ReactionRemoved <$> v .: "user" <*> v .:? "name" <*> v .: "item" <*> v .: "event_ts"
       "star_added" ->  StarAdded <$> v .: "user" <*> v .: "item" <*> v .: "event_ts"
       "star_removed" -> StarRemoved <$> v .: "user" <*> v .: "item" <*> v .: "event_ts"
       "emoji_changed" -> EmojiChanged <$> v .: "event_ts"


### PR DESCRIPTION
I got the behavior wrong for the reaction events -- apparently the `name` field is optional (though the docs never imply this . . .)