### PR TITLE
Expect file and comment IDs rather than inlined JSON objects when par…

### DIFF
--- a/src/Web/Slack/Types/Item.hs
+++ b/src/Web/Slack/Types/Item.hs
@@ -14,8 +14,8 @@ import Control.Lens.TH
 import Prelude
 
 data Item = MessageItem ChannelId MessageUpdate
-          | FileItem File
-          | FileCommentItem File Comment
+          | FileItem FileId
+          | FileCommentItem FileId CommentId
           | ChannelItem ChannelId
           | IMItem ChannelId
           | GroupItem GroupId deriving Show
@@ -26,7 +26,7 @@ instance  FromJSON Item where
                 case typ of
                   "message" -> MessageItem <$> o .: "channel" <*> o .: "message"
                   "file" -> FileItem <$> o .: "file"
-                  "file_comment" -> FileCommentItem <$> o .: "file" <*> o .: "comment"
+                  "file_comment" -> FileCommentItem <$> o .: "file" <*> o .: "file_comment"
                   "channel" -> ChannelItem <$> o .: "channel"
                   "im"      -> IMItem <$> o .: "channel"
                   "group"   -> GroupItem <$> o .: "group"


### PR DESCRIPTION
Expect file and comment IDs rather than inlined JSON objects when parsing 'item' data.

This came up while digging into #21.