### PR TITLE
Make the 'message' sub-field of an 'Item' optional (it does not occur…

### DIFF
--- a/src/Web/Slack/Types/Item.hs
+++ b/src/Web/Slack/Types/Item.hs
@@ -13,7 +13,7 @@ import Web.Slack.Types.Base
 import Control.Lens.TH
 import Prelude
 
-data Item = MessageItem ChannelId MessageUpdate
+data Item = MessageItem ChannelId (Maybe MessageUpdate)
           | FileItem File
           | FileCommentItem File Comment
           | ChannelItem ChannelId
@@ -24,7 +24,7 @@ instance  FromJSON Item where
   parseJSON = withObject "item" (\o -> do
                 (typ :: String) <- o .: "type"
                 case typ of
-                  "message" -> MessageItem <$> o .: "channel" <*> o .: "message"
+                  "message" -> MessageItem <$> o .: "channel" <*> o .:? "message"
                   "file" -> FileItem <$> o .: "file"
                   "file_comment" -> FileCommentItem <$> o .: "file" <*> o .: "comment"
                   "channel" -> ChannelItem <$> o .: "channel"


### PR DESCRIPTION
Make the 'message' sub-field of an 'Item' optional (it does not occur in the 'item' objects in reaction events).

This is more fallout from #21.  The code here doesn't match the API docs for the RTM API or any message items I've seen so far, but I haven't restructured the `MessageItem` field, because a) we know the API docs are incorrect and b) I don't know where the code came from, and maybe it's still valid elsewhere.