### PR TITLE
Add TeamMigrationStarted Event Type

### DIFF
--- a/src/Web/Slack/Types/Event.hs
+++ b/src/Web/Slack/Types/Event.hs
@@ -89,6 +89,7 @@ data Event where
   MessageError :: Int -> SlackError -> Event
   StatusChange :: UserId -> Text -> SlackTimeStamp -> Event
   Pong :: Time -> Event
+  TeamMigrationStarted :: Event
   -- Unstable
   PinAdded :: Event
   PinRemoved :: Event
@@ -183,6 +184,7 @@ parseType o@(Object v) typ =
       "accounts_changed" -> pure AccountsChanged
       "status_change" -> StatusChange <$> v .: "user" <*> v .: "status" <*> v .: "event_ts"
       "pong" -> Pong <$> v .: "timestamp"
+      "team_migration_started" -> pure TeamMigrationStarted
       "pin_added" -> pure PinAdded
       "pin_removed" -> pure PinRemoved
       _ -> return $ UnknownEvent o


### PR DESCRIPTION
Proposed fix to #38. From the documentation (https://api.slack.com/events/team_migration_started), it appears the client will get disconnected after this event is sent. It appears for now that any reconnection logic should be handled by the user, rather than included in this module, so I have not spent much time looking into that area.