### PR TITLE
Add ReconnectUrl type

### DIFF
--- a/src/Web/Slack/Types/Event.hs
+++ b/src/Web/Slack/Types/Event.hs
@@ -89,6 +89,7 @@ data Event where
   MessageError :: Int -> SlackError -> Event
   StatusChange :: UserId -> Text -> SlackTimeStamp -> Event
   Pong :: Time -> Event
+  ReconnectUrl :: URL -> Event
   TeamMigrationStarted :: Event
   -- Unstable
   PinAdded :: Event
@@ -184,6 +185,7 @@ parseType o@(Object v) typ =
       "accounts_changed" -> pure AccountsChanged
       "status_change" -> StatusChange <$> v .: "user" <*> v .: "status" <*> v .: "event_ts"
       "pong" -> Pong <$> v .: "timestamp"
+      "reconnect_url" -> ReconnectUrl <$> v .: "url"
       "team_migration_started" -> pure TeamMigrationStarted
       "pin_added" -> pure PinAdded
       "pin_removed" -> pure PinRemoved


### PR DESCRIPTION
When leaving client connected, get periodic JSON with type of "reconnect_url"
and a websocket URL in the "url" field. Documentation seems to indicate that
when a client gets disconnected, the correct resolution is to call rtm.start
method again. Unsure what the correct course is, but adding support for
the type.

Below is example of JSON response:

{
"type": "reconnect_url",
"url": "wss://mp.slack-msgs.com/websocket/yAj-3m8m-jVvwipOeGxPEJxsXbOma3h0kTsAnVK4eoYIOmek8BSZK702O8mqYoTBYgQ_9bLH6QN-TiQqS_-_bJUnMi6g8uvZ3tA4Jt3zlX-3VrUfM7-DSziJuYjjdLlHu0twpZjty7I8SHARqCfIgk4l_DzTrGeyWLicKHR-W60="
}