### PR TITLE
Change pref types to match current API

### DIFF
--- a/src/Web/Slack/Types/Preferences.hs
+++ b/src/Web/Slack/Types/Preferences.hs
@@ -87,7 +87,7 @@ data Preferences = Preferences
                  , _prefMutedChannels                   :: Text
                  , _prefPrivacyPolicySeen               :: Bool
                  , _prefSearchExcludeBots               :: Bool
-                 , _prefFuzzyMatching                   :: Bool
+                 , _prefFuzzyMatching                   :: Maybe Bool
                  } deriving Show
 
 

--- a/src/Web/Slack/Types/TeamPreferences.hs
+++ b/src/Web/Slack/Types/TeamPreferences.hs
@@ -44,7 +44,7 @@ data TeamPreferences = TeamPreferences
                      , _teamGroupRetentionDuration :: Int
                      , _teamDmRetentionType        :: Int
                      , _teamDmRetentionDuration    :: Int
-                     , _teamRequireAtForMention    :: Int
+                     , _teamRequireAtForMention    :: Bool
                      } deriving Show
 
 


### PR DESCRIPTION
Fixes #45 

In self preferences, set _prefFuzzyMatching to Maybe Bool. Have seen behavior in recent weeks where this field is sometimes in API response, and other times is not.

In team preferences, change _teamRequireAtForMention from Int to Bool. Current interaction with API has it returning Boolean values for this field.

Unfortunately, I am unable to find any documentation to support these changes. Just manually reviewing the API responses I'm receiving.