### PR TITLE
Don't fail if session parsing fails

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -79,12 +79,12 @@ runBot conf bot start = do
     putStrLn "Unable to connect"
     ioError . userError . T.unpack $ r ^. responseBody . key "error" . _String)
   let Just url = r ^? responseBody . key "url" . _String
-  (sessionInfo :: SlackSession) <-
+  (mSessionInfo :: Maybe SlackSession) <-
     case eitherDecode (r ^. responseBody) of
-      Left e -> print (r ^. responseBody) >> (ioError . userError $ e)
-      Right res -> return res
+      Left e -> print (r ^. responseBody) >> (print e) >> (return Nothing)
+      Right res -> return $ Just res
   let partialState :: Metainfo -> SlackState s
-      partialState metainfo = SlackState metainfo sessionInfo start conf
+      partialState metainfo = SlackState metainfo mSessionInfo start conf
   putStrLn "rtm.start call successful"
   case parseWebSocketUrl (T.unpack url) of
     Just (host, path) ->

--- a/src/Web/Slack/State.hs
+++ b/src/Web/Slack/State.hs
@@ -33,7 +33,7 @@ instance Show Metainfo where
 
 data SlackState s = SlackState
                 { _meta      :: Metainfo      -- ^ Information about the connection
-                , _session   :: SlackSession  -- ^ Information about the session at the
+                , _session   :: Maybe SlackSession  -- ^ Information about the session at the
                                                   -- start of the connection
                 , _userState :: s             -- ^ User defined state
                 , _config    :: SlackConfig   -- ^ A copy of the initial configuration


### PR DESCRIPTION
When initiating the RTM connection, the JSON returned from the `rtm.start` method is quite large. It would be easy for this JSON to have bugs or change with versions. Not all applications need this session info so I would like to propose that instead of throwing an exception, it would print the error and proceed. This allows the user of this lib to decide if they don't care about the session or if they would like to crash the program.

One way to tackle this is to use the `Maybe` type. I'm also ok with other suggestions if someone sees a nicer way to solve this.