### PR TITLE
Made it possible to send message from another thread

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -45,6 +45,7 @@ module Web.Slack ( runBot
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 #endif
+import           Control.Concurrent (newMVar)
 import           Control.Lens
 import           Control.Monad.Except
 import qualified Control.Monad.State        as S
@@ -87,7 +88,8 @@ runBot conf bot start = do
 
 mkBot :: (Metainfo -> SlackState s) -> SlackBot s -> WS.ClientApp ()
 mkBot partialState bot conn = do
-    let initMeta = Meta conn 0
+    c <- newMVar 0
+    let initMeta = Meta conn c
     WS.forkPingThread conn 10
     botLoop (partialState initMeta) bot
 

--- a/src/Web/Slack/Message.hs
+++ b/src/Web/Slack/Message.hs
@@ -1,12 +1,14 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
-module Web.Slack.Message (sendMessage, makePingPacket, ping) where
+module Web.Slack.Message (sendMessage, sendMessageLater, ping, pingLater) where
 
 import           Control.Applicative
 import           Control.Lens
 import           Control.Monad.State
-import           Data.Aeson          (encode)
+import           Data.Aeson          (encode, ToJSON)
+import           Data.Aeson.TH
+import           Data.Char
 import qualified Data.Text           as T
 import qualified Network.WebSockets  as WS
 import           Web.Slack.State
@@ -15,31 +17,37 @@ import           Data.Time.Clock.POSIX
 
 import Prelude
 
+-- | Returns an action in IO that can be used to send any payload
+-- The payload should use the unique provided id
+sendLater :: ToJSON a => Slack s ((Int -> a) -> IO ())
+sendLater = do
+  conn <- use connection
+  counter <- use (meta . msgCounter)
+  let send payload = do uid <- nextId counter
+                        liftIO $ WS.sendTextData conn (encode (payload uid))
+  return send
+
 -- | Send a message to the specified channel.
 --
 -- If the message is longer than 4000 bytes then the connection will be
 -- closed.
 sendMessage :: ChannelId -> T.Text -> Slack s ()
 sendMessage cid message = do
-  conn <- use connection
-  uid  <- counter
-  let payload = MessagePayload uid "message" cid message
-  slackLog payload
-  liftIO $ WS.sendTextData conn (encode payload)
+  send <- sendMessageLater
+  liftIO (send cid message)
 
-makePingPacket :: Slack s (IO ())
-makePingPacket = do
-  conn <- use connection
-  uid <- counter
-  now <- round <$> liftIO getPOSIXTime
-  let payload = PingPayload uid "ping" now
-  return (ping conn payload)
-
+-- | Returns an IO action that can be used to send a message
+sendMessageLater :: Slack s (ChannelId -> T.Text -> IO ())
+sendMessageLater = do sender <- sendLater
+                      return (\cid message -> sender (\uid -> MessagePayload uid "message" cid message))
 
 -- | Send a ping packet to the server
 -- The server will respond with a @pong@ `Event`.
-ping :: WS.Connection -> PingPayload -> IO ()
-ping conn payload =
-  WS.sendTextData conn (encode payload)
+ping :: Slack s ()
+ping = pingLater >>= liftIO
 
-
+-- | Returns an IO action that sends a ping packet to the server
+pingLater :: Slack s (IO ())
+pingLater = do sender <- sendLater
+               return $ do now <- round <$> liftIO getPOSIXTime
+                           sender (\uid -> PingPayload uid "ping" now)


### PR DESCRIPTION
For that, I changed the uid counter from `Int` to `MVar Int` (which can
be shared and used between multiple threads).

Now, on top of the of `sendMessage` (`ChannelId -> T.Text -> Slack s ()`,
there is `sendMessageLater` (`Slack s (ChannelId -> T.Text -> IO ())`),
which returns an IO action that can be passed to another thread can be
used to send a message later.
