### PR TITLE
Export Id constructors

### DIFF
--- a/src/Web/Slack/Types/Id.hs
+++ b/src/Web/Slack/Types/Id.hs
@@ -8,7 +8,7 @@ module Web.Slack.Types.Id
     GroupId,
     IMId,
     TeamId,
-    Id,
+    Id(..),
     getId
   ) where
 


### PR DESCRIPTION
This allows library users to construct Id types from text. This is
really useful when the id was stored in a database as a string and needs
to be constructed back into it's Id type before using it with this
library. 

Solves #54 