### PR TITLE
Be more flexible parsing inconsistent Time values

### DIFF
--- a/src/Web/Slack/Types/Time.hs
+++ b/src/Web/Slack/Types/Time.hs
@@ -23,8 +23,13 @@ instance FromJSON SlackTimeStamp where
   parseJSON = withText "SlackTimeStamp"
                 (\s -> let (ts, tail -> uid) = break (== '.') (T.unpack s) in
                   SlackTimeStamp
-                    <$> fmap (Time . realToFrac) (readZ ts :: Parser Integer)
+                    <$> parseTimeString ts
                     <*> readZ uid)
 
 instance FromJSON Time where
-  parseJSON = withScientific "Time" (return . Time . realToFrac)
+  parseJSON (Number s) = return $ Time $ realToFrac s
+  parseJSON (String t) = parseTimeString $ T.unpack t
+  parseJSON _ = empty
+
+parseTimeString :: String -> Parser Time
+parseTimeString s = fmap (Time . realToFrac) (readZ s :: Parser Integer)


### PR DESCRIPTION
Slack's API sometimes returns strings and sometimes returns integers for
times. This was causing the `channel_rename` feature to fail, since it
was returning the channels `created` attribute as a string, and we were
only parsing integer values. This commit fixes that by adding a second
function head to parse string values.

Fixes: https://github.com/mpickering/slack-api/issues/34