### PR TITLE
Drop OpenSSL

### DIFF
--- a/slack-api.cabal
+++ b/slack-api.cabal
@@ -80,8 +80,8 @@ Library
     monad-loops >= 0.4,
     transformers >= 0.3,
     time >= 1.4,
-    wuss,
-    tls
+    wuss >= 1.0,
+    tls >= 1.3
 
 Test-Suite tests
     Type: exitcode-stdio-1.0

--- a/slack-api.cabal
+++ b/slack-api.cabal
@@ -72,8 +72,6 @@ Library
     lens-aeson >= 1.0 ,
     network >= 2.6,
     network-uri >= 2.6,
-    openssl-streams >= 1.2,
-    HsOpenSSL >= 0.11 ,
     io-streams >= 1.2,
     mtl >= 2.1,
     aeson >= 0.8 ,
@@ -81,7 +79,9 @@ Library
     errors >= 1.4 && < 3.0,
     monad-loops >= 0.4,
     transformers >= 0.3,
-    time >= 1.4
+    time >= 1.4,
+    wuss,
+    tls
 
 Test-Suite tests
     Type: exitcode-stdio-1.0


### PR DESCRIPTION
Replace HsOpenSSL with tls.

This replaces the dependency on OpenSSL with a pure Haskell based
version. Also adds tfausak/wuss, which abstracts away the secure
websocket initialization.

Fixes #62 