### PR TITLE
Remove nonexistent fields from Preferences

### DIFF
--- a/src/Web/Slack/Types/Preferences.hs
+++ b/src/Web/Slack/Types/Preferences.hs
@@ -72,9 +72,6 @@ data Preferences = Preferences
                  , _prefSidebarThemeCustomValues        :: Text
                  , _prefFKeySearch                      :: Bool
                  , _prefKKeyOmnibox                     :: Bool
-                 , _prefSpeakGrowls                     :: Bool
-                 , _prefMacSpeakVoice                   :: Text
-                 , _prefMacSpeakSpeed                   :: Int
                  , _prefPushAtChannelSuppressedChannels :: Text
                  , _prefPromptedForEmailDisabling       :: Bool
                  , _prefFullTextExtracts                :: Bool
@@ -92,4 +89,3 @@ $(deriveJSON defaultOptions {fieldLabelModifier = \case
 -- Bad performance regression from lens 4.6 causes GHC to run out of memory
 -- on compilation
 makeLenses ''Preferences
-


### PR DESCRIPTION
It looks like these fields were removed from the rtm startup preferences. I have no idea what they are used for. I just noticed that our slack bot wouldn't start any more because these fields were missing.

I did a curl against the rtm start endpoint like so:

```sh
curl https://slack.com/api/rtm.start -F token=my_token
```

...and indeed these fields were not present.

