### PR TITLE
Fixes #78: type mismatch for _teamIconDefault - changed Bool to String

### DIFF
--- a/src/Web/Slack/Types/Team.hs
+++ b/src/Web/Slack/Types/Team.hs
@@ -28,7 +28,7 @@ data TeamIcons = TeamIcons
                , _teamIcon88      :: URL
                , _teamIcon102     :: URL
                , _teamIcon132     :: URL
-               , _teamIconDefault :: Maybe Bool
+               , _teamIconDefault :: Maybe String
                } deriving Show
 
 makeLenses ''Team


### PR DESCRIPTION
This PR changes the `_teamIconDefault` type from `Bool` to `String` to get things working in #78.

I see this as a temporary fix because like @srhb reported on #78, the [slack docs](https://api.slack.com/methods/rtm.start) are misleading: https://github.com/slackhq/slack-api-docs/issues/79