### PR TITLE
Type mismatch for team icon has been fixed by Slack HQ - revert #78

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,3 @@
-## Unreleased
-
-* Changed type of _teamIconDefault from `Maybe Bool` to `Maybe Text`
-
 ## 0.12
 
 * Remove _prefSpeakGrowls, _prefMacSpeakVoice, _prefMacSpeakSpeed

--- a/src/Web/Slack/Types/Team.hs
+++ b/src/Web/Slack/Types/Team.hs
@@ -28,7 +28,7 @@ data TeamIcons = TeamIcons
                , _teamIcon88      :: URL
                , _teamIcon102     :: URL
                , _teamIcon132     :: URL
-               , _teamIconDefault :: Maybe Text
+               , _teamIconDefault :: Maybe Bool
                } deriving Show
 
 makeLenses ''Team


### PR DESCRIPTION
This reverts the temporary changes from #79 (issue #78).  Slack HQ has fixed the type problem, so we can revert the default team icon type back to `Bool`.

Please see this slack issue for more info:  https://github.com/slackhq/slack-api-docs/issues/79