### PR TITLE
Change type of Time from NominalDiffTime to Int

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Changed `newtype Time = Time NominalDiffTime` to `newtype Time = Time Int`
+
 ## 0.12
 
 * Remove _prefSpeakGrowls, _prefMacSpeakVoice, _prefMacSpeakSpeed

--- a/slack-api.cabal
+++ b/slack-api.cabal
@@ -74,6 +74,7 @@ library
     , mtl >= 2.1
     , network >= 2.6
     , network-uri >= 2.6
+    , scientific >= 0.3.2.0 && < 0.4
     , text >= 1.2
     , time >= 1.4
     , time-locale-compat >= 0.1 && < 0.2


### PR DESCRIPTION
This change is necessary for API functions that require timestamps to be sent back to Slack. We don't want to lose precision by storing unix timestamps as floating-point values.