### PR TITLE
Fix dropped query param in WS uri.

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -105,7 +105,7 @@ parseWebSocketUrl :: Monad m => T.Text -> ExceptT T.Text m (String, String)
 parseWebSocketUrl url = do
     uri  <- URI.parseURI (T.unpack url) ?? ("Couldn't parse WebSockets URL: " <> url)
     auth <- URI.uriAuthority uri ?? ("No authority: " <> url)
-    return (URI.uriRegName auth, URI.uriPath uri)
+    return (URI.uriRegName auth, URI.uriPath uri ++ URI.uriQuery uri)
 
 -- | Retrieve the config used to initiate the session.
 getConfig :: SlackHandle -> SlackConfig


### PR DESCRIPTION
    Slack started adding query params (e.g. "?dp=1") to some of the WSS
    urls it sends back. These were being dropped by parseWebSocketUrl,
    resulting in empty responses and the following message:

        "{}"
        Error in $: key "ok" not present
        Please report this failure to the github issue tracker

Fixes #87