### PR TITLE
Remove email_misc field from Preferences

### DIFF
--- a/src/Web/Slack/Types/Preferences.hs
+++ b/src/Web/Slack/Types/Preferences.hs
@@ -22,7 +22,6 @@ data Preferences = Preferences
                  , _prefPushLoudChannelsSet             :: Text
                  , _prefEmailAlerts                     :: Text
                  , _prefEmailAlertsSleepUntil           :: Int
-                 , _prefEmailMisc                       :: Bool
                  , _prefEmailWeekly                     :: Bool
                  , _prefWelcomeMessageHidden            :: Bool
                  , _prefAllChannelsLoud                 :: Bool


### PR DESCRIPTION
Slack doesn't seem to be returning this field for us anymore, which
leads to crashes at startup unless we remove the field.