### PR TITLE
Remove full_text_extracts field from Preferences

### DIFF
--- a/src/Web/Slack/Types/Preferences.hs
+++ b/src/Web/Slack/Types/Preferences.hs
@@ -73,7 +73,6 @@ data Preferences = Preferences
                  , _prefKKeyOmnibox                     :: Bool
                  , _prefPushAtChannelSuppressedChannels :: Text
                  , _prefPromptedForEmailDisabling       :: Bool
-                 , _prefFullTextExtracts                :: Bool
                  , _prefNoTextInNotifications           :: Bool
                  , _prefMutedChannels                   :: Text
                  , _prefPrivacyPolicySeen               :: Bool


### PR DESCRIPTION
Slack doesn't seem to be returning this field for us anymore, which
leads to crashes at startup unless we remove the field.