### PR TITLE
Make deleted JSON key in User optional with default False

### DIFF
--- a/src/Web/Slack/Types/User.hs
+++ b/src/Web/Slack/Types/User.hs
@@ -26,7 +26,8 @@ data User = User
           } deriving (Show)
 
 instance FromJSON User where
-  parseJSON = withObject "User" (\o -> User <$> o .: "id" <*> o .: "name" <*> o .: "deleted"
+  parseJSON = withObject "User" (\o -> User <$> o .: "id" <*> o .: "name"
+                                        <*> (o .:? "deleted" .!= False)
                                         <*> (o .:? "color" .!= "000000")
                                         <*> o .: "profile" <*> (parseJSON (Object o) :: Parser Permissions)
                                         <*> fmap (fromMaybe False) (o .:? "has_files")


### PR DESCRIPTION
In situations where two Slack teams/communities share a channel, a `user_change` event from a different team/community can be sent to the bot in the other community without the deleted flag provided. Defaults unprovided `deleted` flag in payload to `False` based on this one real world example. Couldn't find Slack documentation about what should be assumed.

Fixes #102.