### PR TITLE
Add .ghc.environment.*, dist-newstyle, and dist to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .stack-work
 stack.yaml
+.ghc.environment.*
+dist-newstyle
+dist


### PR DESCRIPTION
While working on #103 I noticed these locally generated files or directories were not ignored in `.gitignore`. Kept this commit separate from the other patch to keep their acceptance independent. Thanks.