### PR TITLE
Correct FileChange Event

### DIFF
--- a/src/Web/Slack/Types/Event.hs
+++ b/src/Web/Slack/Types/Event.hs
@@ -43,7 +43,7 @@ data Event where
   CommandsChanged :: SlackTimeStamp -> Event
   EmailDomainChange :: Domain -> SlackTimeStamp -> Event
   EmojiChanged :: SlackTimeStamp -> Event
-  FileChange  :: File -> Event
+  FileChange  :: FileChangeInfo -> Event
   FileCommentAdded :: File -> Comment -> Event
   FileCommentDeleted :: File -> CommentId -> Event
   FileCommentEdited :: File -> Comment -> Event
@@ -130,7 +130,7 @@ parseType o@(Object v) typ =
       "commands_changed" -> CommandsChanged <$> v .: "event_ts"
       "email_domain_changed" -> EmailDomainChange <$> v .: "email_domain" <*> v .: "event_ts"
       "emoji_changed" -> EmojiChanged <$> v .: "event_ts"
-      "file_change"  -> FileChange <$> v .: "file"
+      "file_change"  -> FileChange <$> parseJSON o
       "file_comment_added" -> FileCommentAdded <$> v .: "file" <*> v .: "comment"
       "file_comment_deleted" -> FileCommentDeleted <$> v .: "file" <*> v .: "comment"
       "file_comment_edited" -> FileCommentEdited <$> v .: "file" <*> v .: "comment"

--- a/src/Web/Slack/Types/File.hs
+++ b/src/Web/Slack/Types/File.hs
@@ -16,6 +16,24 @@ import Web.Slack.Types.Base
 
 import Prelude
 
+newtype FileChangeFile = FileChangeFileInfo { _fileChangeFileInfoFileId :: FileId }  deriving (Show)
+
+instance FromJSON FileChangeFile where
+  parseJSON = withObject "FileChangeFile" (\o -> FileChangeFileInfo <$> o .: "id" )
+
+-- | Event information for when a file changes.  Note, the Slack API
+-- information for this type, as of 2019-08-16, is incorrect in quite
+-- a few ways.
+data FileChangeInfo = FileChangeInfo { _fileChangeInfoFileId :: FileId
+                             , _fileChangeInfoUserId :: UserId
+                             , _fileChangeInfoFile :: FileChangeFile
+                             , _fileChangeInfoEventTS :: SlackTimeStamp
+                             , _fileChangeInfoTS :: Maybe SlackTimeStamp
+                             } deriving (Show)
+
+instance FromJSON FileChangeInfo where
+  parseJSON = withObject "FileChangeInfo" (\o -> FileChangeInfo <$> o .: "file_id" <*> o .: "user_id" <*> o .: "file" <*> o .: "event_ts" <*> o .:? "ts")
+
 data File = File { _fileId             :: FileId
                  , _fileTimestamp      :: Time
                  , _fileName           :: Maybe Text


### PR DESCRIPTION
The "file\_change" event did not conform to the Slack API. It was attempting to read an entire "file" object, as though this was a "file\_created" event. Making matters a bit more complicated the Slack API itself does not correctly document all of the fields on the event.

Due to the somewhat large number of fields, and in an attempt to keep with general idioms for the `Event` GADT, the `FileChange` event now wraps a `FileChangeInfo` value. The primary advantage here is that we get record functions for accessing the members. In the future we may want to consider some more significant changes.